### PR TITLE
Dependency updates, typo fixes and readme update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,114 @@ and
 ## Usage
 Only one node (besides the config node) are necessary for operation. After the configuration has been successful -- either by providing an existing identity and PSK or by generating a new Identity and PSK by providing the security code from the gateway -- simply select which light to target and check if the node should observe the device as well. Its also possible to select [All devices] and control an entire group.
 
+### Controlling the node
+Nodes can be programmatically controlled by sending a message with `msg.payload` set to one of the following strings:
+* `"status"` The node will output the current status of its target light.
+
+### Controlling a light
+Lights can be controlled by sending an objet with one or more of the following properties as `msg.payload` to the node.
+* `onOff` `boolean` Turn the light on (`true`) or off (`false`).
+* `dimmer` `number` `[0,100]` The brightness of the light.
+* `colorTemperature` `number` `[0,100]` The color temperature of the light (cold white: `0`, warm white `100`).
+* `color` `string` Sets the color of the light. For WS-bulbs, `F5FAF6`, `F1E0B5` and `EFD275` will set the light to the default cold, normal and warm temperatures respectively.
+* `transition` `number` The default transition time for operations. Will only work for single operation commands and not for on/off. Defaults to 0. 
+* `hue` `number` `[0,360]` Sets the hue of the light.
+* `saturation` `number` `[0,100]` Sets the saturation of the light.
+
+### Controlling a group
+A group can be controlled by selecting [All devices] and sending an object with one or more of the following properties as `msg.payload` to the node.
+* `dimmer` `number` The brightness in percent [0..100%].
+* `onOff` `boolean` If the lightbulb is on (`true`) or off (`false`)
+* `transitionTime` `number` The duration of state changes in seconds. Default 0.5s, not supported for on/off.
+* `sceneId` `number` Set this to the instanceId of a scene (or "mood" as IKEA calls them), to activate it.
+
+### Observing a light
+If the node is set to observe it will send a message with the light's current properties as payload every time the light is updated:
+* `name` `string` The name of this accessory as displayed in the app. Defaults to the model name.
+* `createdAt` `number` The unix timestamp of the creation of the device. Unknown what this is exactly.
+* `instanceId` `number` The ID under which the accessory is known to the gateway. Is used in callbacks throughout the library.
+* `deviceInfo` `DeviceInfo{}` Some additional information about the device in form of a `DeviceInfo` object (see below)
+* `alive` `boolean` Whether the gateway considers this device as alive.
+* `lastSeen` `number` The unix timestamp of the last communication with the gateway.
+* `lightList` `Light[]` An array of all lights belonging to this accessory in form of a `Light[]` array (see below).
+* `otaUpdateState` `number` Unknown. Might be a boolean
+`DeviceInfo` object
+* `battery` `number` The battery percentage of a device. Only present if the device is battery-powered.
+* `firmwareVersion` `string` The firmware version of the device
+* `manufacturer` `string` The device manufacturer. Usually "IKEA of Sweden".
+* `modelNumber` `string` The name/type of the device, e.g. "TRADFRI bulb E27 CWS opal 600lm"
+* `power` `PowerSources` How the device is powered. One of the following enum values:
+  * `Unknown (0)`
+  * `InternalBattery (1)`
+  * `ExternalBattery (2)`
+  * `Battery (3)`
+
+  Although not in the specs, this is apparently used by the remote
+  * `PowerOverEthernet (4)`
+  * `USB (5)`
+  * `AC_Power (6)`
+  * `Solar (7)`
+* `serialNumber` `string` Not used currently. Always ""
+`Lights` array
+* `dimmer` `number` The brightness in percent [0..100%].
+* `onOff` `boolean` If the lightbulb is on true or off false
+* `transitionTime` `number` The duration of state changes in seconds. Default 0.5s, not supported for on/off.
+* `isSwitchable` `boolean` Whether the lightbulb supports on/off.
+* `isDimmable` `boolean` Whether the lightbulb supports setting the brightness.
+* `spectrum` `"none" | "white" | "rgb"` The supported color spectrum of the lightbulb.
+* `colorTemperature` `number` The color temperature in percent, where 0% equals cold white and 100% equals warm white.
+* `color` `string` The 6 digit hex number representing the lightbulb's color. Don't use any prefixes like "#", only the hex number itself!
+* `hue` `number` The color's hue [0..360°].
+* `saturation` `number` The color's saturation [0..100%].
+
+### Output
+If the node is set to observe and the target light is updated or if triggered manually by sending a `"status"` request as `msg.payload` to the node, the node will send a `msg.payload` with the current status of the light.
+* `id` `number` The id of the light.
+* `name` `string` The given name of the light.
+* `model` `string` The model of the light.
+* `firmware` `string` The firmware of the light.
+* `alive` `boolean` True if the gateway can communicate with the light, false if not.
+* `on` `boolean` True if the light is on, false if not.
+* `brightness` `number` `[0,100]` The brightness of the light.
+* `colorTemperature` `number` `[0,100]` The color temperature of the light.
+* `color` `string` The hex-code for the color of the light. Only fully supported by CWS bulbs.
+* `colorX` `number` The x component of the xy-color.
+* `colorY` `number` The y component of the xy-color.
+* `transition` `number` The default transition time for operations. However, since the default value of 0.5 makes it impossible to send temperature and brightness updates in the same command, this is overridden and set to 0 by default.
+* `created` `number` Probably when the light was paired with the gateway for the first time, measured in epoch time.
+* `seen` `number` When the light was last interacted with by the gateway (or similar), measured in epoch time.
+* `type` `number` The type of device where 2 is light.
+* `power` `number` The type of power source powering the light. Will most likely always be 1.
+
+
+## Installation
+To install this repository in node red execute the following:
+
+### Regular installation
+Execute the following commands:
+* `cd ~/.node-red` (depends where your node-red install directory is)
+* `npm install git+https://github.com/flavorplus/node-red-contrib-node-tradfri.git`
+* (re)start Node-red and the ["]tradfri] node should appear in the [function] list.
+
+### Docker installation
+Note: this has only been tested on a Synology NAS.
+Execute the following commands:
+* `docker exec -it nodered bash` (where nodered is the name of your running node red container)
+* `cd /data`
+* `npm install git+https://github.com/flavorplus/node-red-contrib-node-tradfri.git`
+
+## Building
+Make sure you have [gulp-cli] installed:
+`npm install --global gulp-cli` (you might need to prefix it with `sudo ` in case of an error)
+
+Enter the directory of this repository.
+
+Install all (dev) dependancies with:
+`npm install`
+
+To clean, build and install, execute:
+`gulp`
+
 ## Changelog
 
 ### 0.1.3

--- a/dist/node-tradfri.html
+++ b/dist/node-tradfri.html
@@ -4,7 +4,7 @@
     category: 'config',
     defaults: {
       address: {
-        value: "192.168.50.81",
+        value: "",
         required: true
       },
       name: {
@@ -319,27 +319,27 @@
     <dd> The status of a light or group. </dd>
   </dl>
 
-  <h3>Details</h3> The tradfri node acts as both input and output for a IKEA Tradfri lighbulb(s).
+  <h3>Details</h3> The tradfri node acts as both input and output for IKEA Tradfri lighbulbs.
 
-  <h2>Scenes</h2> When a group is selected, all scenes for that group and their <code>instanceId</code> will be showen for refrence.
+  <h2>Scenes</h2> When a group is selected, all scenes for that group and their <code>instanceId</code> will be showed for refrence.
 
   <h2>Controlling the node</h2> Nodes can be programmatically controlled by sending a message with <code>msg.payload</code> set to one of the following strings:
   <ul>
     <li><code>"status"</code> The node will output the current status of its target light or group.
   </ul>
 
-  <h2>Controlling a light</h2> Lights can be controlled by sending an objet with one or more of the following properties as <code>msg.payload</code> to the node.
+  <h2>Controlling a light</h2> Lights can be controlled by sending an object with one or more of the following properties as <code>msg.payload</code> to the node.
   <ul>
     <li><code>dimmer</code><code>number</code> The brightness in percent [0..100%].</li>
     <li><code>onOff</code><code>boolean</code> If the lightbulb is on <code>true</code> or off <code>false</code></li>
     <li><code>transitionTime</code><code>number</code> The duration of state changes in seconds. Default 0.5s, not supported for on/off.</li>
     <li><code>colorTemperature</code><code>number</code> The color temperature in percent, where 0% equals cold white and 100% equals warm white.</li>
     <li><code>color</code><code>string</code> The 6 digit hex number representing the lightbulb's color. Don't use any prefixes like "#", only the hex number itself!</li>
-    <li><code>hue</code><code>number</code> The colors hue [0..360°].</li>
-    <li><code>saturation</code><code>number</code> The colors saturation [0..100%].</li>
+    <li><code>hue</code><code>number</code> The color's hue [0..360°].</li>
+    <li><code>saturation</code><code>number</code> The color's saturation [0..100%].</li>
   </ul>
 
-  <h2>Controlling a group</h2> A group can be controlled by selecting [All device] and sending an objet with one or more of the following properties as <code>msg.payload</code> to the node.
+  <h2>Controlling a group</h2> A group can be controlled by selecting [All devices] and sending an object with one or more of the following properties as <code>msg.payload</code> to the node.
   <ul>
     <li><code>dimmer</code><code>number</code> The brightness in percent [0..100%].</li>
     <li><code>onOff</code><code>boolean</code> If the lightbulb is on <code>true</code> or off <code>false</code></li>
@@ -347,16 +347,16 @@
     <li><code>sceneId</code><code>number</code> Set this to the <code>instanceId</code> of a scene (or "mood" as IKEA calls them), to activate it.</li>
   </ul>
 
-  <h2>Observing a ligt</h2> If the node is set to observe it will send a message with the lights current properties as payload every time the light is updated:
+  <h2>Observing a light</h2> If the node is set to observe it will send a message with the light's current properties as payload every time the light is updated:
   <ul>
-  <li><code>name</code><code>string</code> The name of this accessory as displayed in the app. Defaults to the model name.</li>
-  <li><code>createdAt</code><code>number</code> The unix timestamp of the creation of the device. Unknown what this is exactly.</li>
-  <li><code>instanceId</code><code>number</code> The ID under which the accessory is known to the gateway. Is used in callbacks throughout the library.</li>
-  <li><code>deviceInfo</code><code>DeviceInfo{}</code> Some additional information about the device in form of a <code>DeviceInfo</code> object (see below)</li>
-  <li><code>alive</code><code>boolean</code> Whether the gateway considers this device as alive.</li>
-  <li><code>lastSeen</code><code>number</code> The unix timestamp of the last communication with the gateway.</li>
-  <li><code>lightList</code><code>Light[]</code> An array of all lights belonging to this accessory in form of a <code>Light[]</code> array (see below).</li>
-  <li><code>otaUpdateState</code><code>number</code> Unknown. Might be a boolean</li>
+    <li><code>name</code><code>string</code> The name of this accessory as displayed in the app. Defaults to the model name.</li>
+    <li><code>createdAt</code><code>number</code> The unix timestamp of the creation of the device. Unknown what this is exactly.</li>
+    <li><code>instanceId</code><code>number</code> The ID under which the accessory is known to the gateway. Is used in callbacks throughout the library.</li>
+    <li><code>deviceInfo</code><code>DeviceInfo{}</code> Some additional information about the device in form of a <code>DeviceInfo</code> object (see below)</li>
+    <li><code>alive</code><code>boolean</code> Whether the gateway considers this device as alive.</li>
+    <li><code>lastSeen</code><code>number</code> The unix timestamp of the last communication with the gateway.</li>
+    <li><code>lightList</code><code>Light[]</code> An array of all lights belonging to this accessory in form of a <code>Light[]</code> array (see below).</li>
+    <li><code>otaUpdateState</code><code>number</code> Unknown. Might be a boolean</li>
   </ul>
 
   <h2><code>DeviceInfo</code> object</h2>
@@ -389,7 +389,7 @@
     <li><code>spectrum</code><code>"none" | "white" | "rgb"</code> The supported color spectrum of the lightbulb.</li>
     <li><code>colorTemperature</code><code>number</code> The color temperature in percent, where 0% equals cold white and 100% equals warm white.</li>
     <li><code>color</code><code>string</code> The 6 digit hex number representing the lightbulb's color. Don't use any prefixes like "#", only the hex number itself!</li>
-    <li><code>hue</code><code>number</code> The colors hue [0..360°].</li>
-    <li><code>saturation</code><code>number</code> The colors saturation [0..100%].</li>
+    <li><code>hue</code><code>number</code> The color's hue [0..360°].</li>
+    <li><code>saturation</code><code>number</code> The color's saturation [0..100%].</li>
   </ul>
 </script>

--- a/dist/node-tradfri.js
+++ b/dist/node-tradfri.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -50,8 +51,6 @@ module.exports = function (RED) {
         RED.nodes.createNode(node, config);
         node.name = config.name;
         node.address = config.address;
-        node.credentials.identity = "tradfri_1526131982225";
-        node.credentials.psk = "GTcy1xDnUR4wkwAJ";
         if ((typeof node.credentials.identity === 'undefined' && typeof node.credentials.psk !== 'undefined') || (typeof node.credentials.identity !== 'undefined' && typeof node.credentials.psk === 'undefined')) {
             RED.log.error("Must provide both identity and PSK or leave both blank to generate new credentials from security code.");
         }
@@ -205,7 +204,10 @@ module.exports = function (RED) {
         };
         node.on('close', () => {
             clearInterval(_ping);
-            _client.destroy();
+            if (_client != null) {
+                _client.destroy();
+                _client = null;
+            }
             RED.log.debug(`[Tradfri: ${node.id}] Config was closed`);
         });
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ gulp.task('clean:build', () => {
     return del(['./build/**']);
 });
 
-gulp.task('compile', ['clean:build'], () => {
+gulp.task('compile', gulp.series('clean:build', () => {
     let numErrors = 0;
     let res = gulp.src('src/**/*.ts')
         .pipe(
@@ -21,16 +21,17 @@ gulp.task('compile', ['clean:build'], () => {
             numErrors += 1;
         })
     return res.pipe(gulp.dest('build'))
-});
+}));
 
-gulp.task('install', ['compile'], () => {
+gulp.task('install', gulp.series('compile', () => {
     return gulp.src(['src/*.html', 'build/*.js'])
         .pipe(gulp.dest('dist'));
-});
+}));
 
-gulp.task('exec', ['install'], shell.task('docker restart node-red'));
+gulp.task('exec', gulp.series('install', shell.task('docker restart node-red')));
+
 gulp.task('watch', function() {
     return gulp.watch(['src/*.html', 'src/*.ts'], ['exec']);
 });
 
-gulp.task('default', ['install']);
+gulp.task('default', gulp.series('install'));

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "devDependencies": {
         "@types/node": "^8.5.5",
         "del": "^3.0.0",
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.1",
         "gulp-shell": "^0.6.5",
         "gulp-typescript": "^3.2.3",
-        "typescript": "^2.6.2"
+        "typescript": "^3.6.3"
     },
     "dependencies": {
-        "node-tradfri-client": "^1.2.1"
+        "node-tradfri-client": "^2.0.1"
     },
     "node-red": {
         "nodes": {

--- a/src/node-tradfri.html
+++ b/src/node-tradfri.html
@@ -319,27 +319,27 @@
     <dd> The status of a light or group. </dd>
   </dl>
 
-  <h3>Details</h3> The tradfri node acts as both input and output for a IKEA Tradfri lighbulb(s).
+  <h3>Details</h3> The tradfri node acts as both input and output for IKEA Tradfri lighbulbs.
 
-  <h2>Scenes</h2> When a group is selected, all scenes for that group and their <code>instanceId</code> will be showen for refrence.
+  <h2>Scenes</h2> When a group is selected, all scenes for that group and their <code>instanceId</code> will be showed for refrence.
 
   <h2>Controlling the node</h2> Nodes can be programmatically controlled by sending a message with <code>msg.payload</code> set to one of the following strings:
   <ul>
     <li><code>"status"</code> The node will output the current status of its target light or group.
   </ul>
 
-  <h2>Controlling a light</h2> Lights can be controlled by sending an objet with one or more of the following properties as <code>msg.payload</code> to the node.
+  <h2>Controlling a light</h2> Lights can be controlled by sending an object with one or more of the following properties as <code>msg.payload</code> to the node.
   <ul>
     <li><code>dimmer</code><code>number</code> The brightness in percent [0..100%].</li>
     <li><code>onOff</code><code>boolean</code> If the lightbulb is on <code>true</code> or off <code>false</code></li>
     <li><code>transitionTime</code><code>number</code> The duration of state changes in seconds. Default 0.5s, not supported for on/off.</li>
     <li><code>colorTemperature</code><code>number</code> The color temperature in percent, where 0% equals cold white and 100% equals warm white.</li>
     <li><code>color</code><code>string</code> The 6 digit hex number representing the lightbulb's color. Don't use any prefixes like "#", only the hex number itself!</li>
-    <li><code>hue</code><code>number</code> The colors hue [0..360°].</li>
-    <li><code>saturation</code><code>number</code> The colors saturation [0..100%].</li>
+    <li><code>hue</code><code>number</code> The color's hue [0..360°].</li>
+    <li><code>saturation</code><code>number</code> The color's saturation [0..100%].</li>
   </ul>
 
-  <h2>Controlling a group</h2> A group can be controlled by selecting [All device] and sending an objet with one or more of the following properties as <code>msg.payload</code> to the node.
+  <h2>Controlling a group</h2> A group can be controlled by selecting [All devices] and sending an object with one or more of the following properties as <code>msg.payload</code> to the node.
   <ul>
     <li><code>dimmer</code><code>number</code> The brightness in percent [0..100%].</li>
     <li><code>onOff</code><code>boolean</code> If the lightbulb is on <code>true</code> or off <code>false</code></li>
@@ -347,7 +347,7 @@
     <li><code>sceneId</code><code>number</code> Set this to the <code>instanceId</code> of a scene (or "mood" as IKEA calls them), to activate it.</li>
   </ul>
 
-  <h2>Observing a ligt</h2> If the node is set to observe it will send a message with the lights current properties as payload every time the light is updated:
+  <h2>Observing a light</h2> If the node is set to observe it will send a message with the light's current properties as payload every time the light is updated:
   <ul>
     <li><code>name</code><code>string</code> The name of this accessory as displayed in the app. Defaults to the model name.</li>
     <li><code>createdAt</code><code>number</code> The unix timestamp of the creation of the device. Unknown what this is exactly.</li>
@@ -389,7 +389,7 @@
     <li><code>spectrum</code><code>"none" | "white" | "rgb"</code> The supported color spectrum of the lightbulb.</li>
     <li><code>colorTemperature</code><code>number</code> The color temperature in percent, where 0% equals cold white and 100% equals warm white.</li>
     <li><code>color</code><code>string</code> The 6 digit hex number representing the lightbulb's color. Don't use any prefixes like "#", only the hex number itself!</li>
-    <li><code>hue</code><code>number</code> The colors hue [0..360°].</li>
-    <li><code>saturation</code><code>number</code> The colors saturation [0..100%].</li>
+    <li><code>hue</code><code>number</code> The color's hue [0..360°].</li>
+    <li><code>saturation</code><code>number</code> The color's saturation [0..100%].</li>
   </ul>
 </script>

--- a/src/node-tradfri.ts
+++ b/src/node-tradfri.ts
@@ -210,7 +210,10 @@ module.exports = function(RED) {
 
     node.on('close', () => {
       clearInterval(_ping);
-      _client.destroy();
+      if (_client != null) {
+        _client.destroy();
+        _client = null;
+      }
       RED.log.debug(`[Tradfri: ${node.id}] Config was closed`);
     });
 


### PR DESCRIPTION
When looking for a working tradfri node red implementation I came across @freahs implementation with group support (and active maintenance) on this fork.

I ran into problems connecting (See [last comment on freahs' issue 3](https://github.com/freahs/node-red-contrib-node-tradfri/issues/3#issuecomment-489344772)), and decided to look into it.

Had some `gulp` build problems (version 3 is unsupported now), so I bumped the versions of gulp, which also needed a new version of typescript.
Bumped the node-tradfri-client as well while I was at it.

I also fixed some typos and added the (new) object structures and build instructions to the readme since I really was missing them before deploying to node red.
